### PR TITLE
Feat/reid comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ runs/
 *.pth
 *.csv
 # ignore images
+
+.venv/
+data/
+tmp/

--- a/README.md
+++ b/README.md
@@ -1,218 +1,305 @@
-# LITE: A Paradigm Shift in Multi-Object Tracking with Efficient ReID Feature Integration
+# LITE: Efficient ReID Feature Integration for Multi-Object Tracking
 
-> [**LITE: A Paradigm Shift in Multi-Object Tracking with Efficient ReID Feature Integration**](http://www.arxiv.org/abs/2409.04187v2)
-> 
-> Jumabek Alikhanov, Dilshod Obidov, Hakil Kim
-> 
-> *[arXiv 2409.04187](http://www.arxiv.org/abs/2409.04187v2)*
-> 
-> *![Published at ICONIP2024](assets/ICONIP2024_Certificate_of_Presentation_Paper_1.pdf)*
-> 
-> Download the full paper from this repo: [docs/LITE.pdf](docs/LITE.pdf)
->
-> Keywords: multi-object tracking, MOT, object tracking, ReID, computer vision, real-time tracking, LITE, arXiv 2409.04187
+This repository contains the implementation used for:
 
+- [LITE: A Paradigm Shift in Multi-Object Tracking with Efficient ReID Feature Integration](http://www.arxiv.org/abs/2409.04187v2), ICONIP 2024
+- [Practical Evaluation Framework for Real-Time Multi-Object Tracking: Achieving Optimal and Realistic Performance](https://doi.org/10.1109/ACCESS.2025.3541177), IEEE Access 2025
 
-# Practical Evaluation Framework for Real-Time Multi-Object Tracking: Achieving Optimal and Realistic Performance
+Authors: Jumabek Alikhanov, Dilshod Obidov, Mirsaid Abdurasulov, Hakil Kim
 
-> [**Practical Evaluation Framework for Real-Time Multi-Object Tracking: Achieving Optimal and Realistic Performance**](https://doi.org/10.1109/ACCESS.2025.3541177)  
-> 
-> Jumabek Alikhanov, Dilshod Obidov, Mirsaid Abdurasulov, Hakil Kim
-> 
-> *IEEE Access, vol. 13, pp. 34768–34788, 2025*
-> 
-> Download the full paper from this repo: [docs/Practical_Evaluation_Framework_for_Real-Time_Multi-Object_Tracking_Achieving_Optimal_and_Realistic_Performance.pdf](docs/Practical_Evaluation_Framework_for_Real-Time_Multi-Object_Tracking_Achieving_Optimal_and_Realistic_Performance.pdf)
->
-> Keywords: Multiple object tracking (MOT), real-time tracking, evaluation framework, LITE, ReID, performance evaluation
-> 
-## Overview
+Paper PDFs are included in [docs/LITE.pdf](docs/LITE.pdf) and [docs/Practical_Evaluation_Framework_for_Real-Time_Multi-Object_Tracking_Achieving_Optimal_and_Realistic_Performance.pdf](docs/Practical_Evaluation_Framework_for_Real-Time_Multi-Object_Tracking_Achieving_Optimal_and_Realistic_Performance.pdf).
 
-LITE (Lightweight Integrated Tracking-Feature Extraction) introduces a groundbreaking approach to enhance ReID-based Multi-Object Tracking (MOT) systems. By integrating appearance feature extraction directly into the detection pipeline, LITE significantly improves computational efficiency while maintaining robust performance. Utilizing CNN-based object detectors like YOLOv8 and YOLO11, LITE enables real-time tracking, making it ideal for resource-constrained environments.
-
----
 ![Efficient ReID feature extraction via the LITE paradigm](assets/Fig02-6390.png)
 
-## Key Features
+## Overview
 
-- **Efficient Integration**: Combines appearance feature extraction within the detection process.
-- **Lightweight Design**: Tailored for real-time applications on resource-limited devices.
-- **Performance Optimization**: Demonstrates notable FPS improvements across multiple trackers while retaining competitive accuracy.
+LITE (Lightweight Integrated Tracking-Feature Extraction) extracts appearance features directly from intermediate YOLO detector features instead of running a separate ReID network for every detection. The repository supports standard trackers and their LITE variants:
 
----
+- DeepSORT and LITE-DeepSORT
+- StrongSORT and LITE-StrongSORT
+- Deep OC-SORT and LITE-Deep OC-SORT
+- BoT-SORT and LITE-BoT-SORT
+- SORT, ByteTrack, and OC-SORT baselines
 
-## Experimental Results
+The paper results use YOLOv8m, input resolution 1280, person class only, confidence threshold 0.25, and `layer14` as the default LITE appearance feature layer unless otherwise stated.
 
-We evaluated LITE using **YOLOv8m** with the following settings:
+## Reported Results
 
-- **Confidence Threshold**: 0.25
-- **Input Resolution**: 1280
+| Tracker | MOT17 HOTA | MOT17 FPS | MOT20 HOTA | MOT20 FPS |
+|---|---:|---:|---:|---:|
+| DeepSORT | 43.7 | 10.5 | 24.4 | 8.5 |
+| StrongSORT | 44.5 | 4.5 | 26.1 | 2.6 |
+| Deep OC-SORT | 43.7 | 10.3 | 24.9 | 8.9 |
+| BoT-SORT | 40.8 | 10.6 | 21.1 | 9.4 |
+| LITE:DeepSORT | 43.0 | 26.7 | 25.2 | 15.9 |
+| LITE:StrongSORT | 42.4 | 29.7 | 25.2 | 22.9 |
+| LITE:Deep OC-SORT | 43.4 | 34.8 | 25.4 | 19.6 |
+| LITE:BoT-SORT | 40.8 | 38.2 | 21.1 | 31.8 |
 
-| Tracker              | MOT17 HOTA ↑ | MOT17 FPS ↑ | MOT20 HOTA ↑ | MOT20 FPS ↑ |
-|----------------------|------------------|----------------|------------------|----------------|
-| DeepSORT            | 43.7            | 10.5           | 24.4            | 8.5            |
-| StrongSORT          | 44.5            | 4.5            | 26.1            | 2.6            |
-| Deep OC-SORT        | 43.7            | 10.3           | 24.9            | 8.9            |
-| BoTSORT             | 40.8            | 10.6           | 21.1            | 9.4            |
-| **LITE:DeepSORT**   | 43.0            | 26.7           | 25.2            | 15.9           |
-| **LITE:StrongSORT** | 42.4            | 29.7           | 25.2            | 22.9           |
-| **LITE:Deep OC-SORT** | 43.4            | 34.8           | 25.4            | 19.6           |
-| **LITE:BoTSORT**    | 40.8            | 38.2           | 21.1            | 31.8           |
----
+Small FPS differences are expected across GPUs, CUDA versions, storage speed, and display/visualization settings. HOTA should be compared using the same TrackEval version, dataset split, confidence threshold, input size, and tracker configuration.
 
-## Installation
+## Environment
 
-Follow these steps to set up the LITE tracking system:
-
-### 1. Clone the Repository
+The experiments were developed for Python 3.10 with CUDA-enabled PyTorch. A clean setup is recommended:
 
 ```bash
-# Clone the LITE Tracker Repository
 git clone https://github.com/Jumabek/LITE.git
 cd LITE
-```
 
-### 2. Set Up Python Environment
+python3.10 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip setuptools wheel
 
-```bash
-# Create and activate a virtual environment
-python3.10 -m venv myenv
-source myenv/bin/activate
-
-# Install dependencies
+# Choose the PyTorch wheel that matches your CUDA driver.
+# This example uses CUDA 12.1.
+pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu121
 pip install -r requirements.txt
+
+# Make local LITE, ultralytics, and yolo_tracking modules importable.
+export PYTHONPATH="$PWD:$PWD/yolo_tracking:$PYTHONPATH"
 ```
 
-### 3. Clone Additional Dependencies
+If you use a different CUDA version, install the matching `torch` and `torchvision` wheels first, then run `pip install -r requirements.txt`.
+
+## External Tools
+
+The repository includes local copies of the modified `ultralytics` and `yolo_tracking` code. For MOT metrics, clone TrackEval next to the project code:
 
 ```bash
-# Clone supplementary repositories
-git clone https://github.com/Jumabek/ultralytics.git
-git clone https://github.com/humblebeeintel/yolo_tracking.git
-git clone https://github.com/humblebeeintel/TrackEval
+git clone https://github.com/JonathonLuiten/TrackEval.git
 ```
 
-### 4. Set Up FastReID
+The evaluation commands below assume `TrackEval/` is in the repository root. If it is elsewhere, replace `TrackEval/scripts/run_mot_challenge.py` with your local path.
+
+## Datasets
+
+Download the prepared datasets with:
 
 ```bash
-bash scripts/setup_fastreid.sh
+bash scripts/download_datasets_from_gdrive.sh
 ```
 
----
+After extraction, the expected structure is:
 
-## Dataset Preparation
-
-Download the prepared datasets from [this link](https://console.cloud.google.com/storage/browser/hbai-general-data/2024/cv.lite/dataset) and organize them as follows:
-
-```plaintext
-LITE/datasets
-   |-- MOT
-   |   |-- train
-   |   |-- test
-   |-- PersonPath22
-   |   |-- test
-   |-- VIRAT-S
-   |   |-- train
-   |-- KITTI
-       |-- train
-       |-- test
+```text
+datasets/
+  MOT17/
+    train/MOT17-02-FRCNN/img1/...
+    train/MOT17-02-FRCNN/gt/gt.txt
+    test/...
+  MOT20/
+    train/MOT20-01/img1/...
+    train/MOT20-01/gt/gt.txt
+    test/...
+  PersonPath22/test/...
+  VIRAT-S/train/...
+  KITTI/train/...
 ```
 
----
+You can also download MOT17/MOT20 from the official MOTChallenge site and arrange the folders in the same layout.
 
 ## Checkpoints
 
-Download the required checkpoints from [this link](https://drive.google.com/file/d/15NBT6pnwzf43MsNu1QK_qC04Efxg0yTP/view?usp=sharing) and place them under `LITE/checkpoints`:
-
-```plaintext
-checkpoints
-└── FastReID
-    ├── bagtricks_S50.yml
-    ├── Base-bagtricks.yml
-    ├── deepsort
-    │   ├── ckpt.t7
-    │   └── original_ckpt.t7
-    └── DukeMTMC_BoT-S50.pth
-```
-
----
-
-## Running Experiments
-
-### 1. Run Tracking and ReID Experiments
+Download and extract ReID checkpoints with:
 
 ```bash
-bash scripts/run_experiment.sh -d <DATASET> -s <SPLIT> -t <TRACKER> -m <YOLO_MODEL>
-# TRACKER options: "SORT", "LITEDeepSORT", "DeepSORT", "StrongSORT", "LITEStrongSORT", "OCSORT", "Bytetrack", "DeepOCSORT", "LITEDeepOCSORT", "BoTSORT", "LITEBoTSORT"
-
-# YOLO_MODEL options: all models of YOLO from yolov8 to yolo11
+bash scripts/prepare_checkpoints.sh
 ```
 
-### 2. Running the ReID Evaluator
-```bash
-python reid.py --dataset <DATASET> --seq_name <SEQ_NAME>  --split <SPLIT>  --tracker <ReID_MODEL> --save
+The expected checkpoint layout is:
+
+```text
+checkpoints/
+  FastReID/
+    bagtricks_S50.yml
+    Base-bagtricks.yml
+    DukeMTMC_BoT-S50.pth
+    deepsort/
+      ckpt.t7
+      original_ckpt.t7
 ```
 
-## Demo
+YOLO weights such as `yolov8m.pt` are loaded from the repository root or downloaded automatically by Ultralytics when available.
 
-Comparison of Tracker and LITE versions. Tracker can be viewed on Google Drive.
-👉[![Watch the demo](https://drive.google.com/file/d/1Oe13xFO4aR5u6UQcNyIQwKwmbl2-iEDl/view?usp=drive_link)
+## Quick Smoke Test
 
-### Download demo videos
-
-```
-bash demo/download_solutions_demo_videos.sh
-```
-
-### Basic Tracking Demo
+Use the included video to verify the environment before running full benchmarks:
 
 ```bash
 python demo.py --source demo/VIRAT_S_010204_07_000942_000989.mp4
 ```
 
-### Object Counter & Heatmap
+This opens an OpenCV display window. Press `q` to stop. On a headless server, run the benchmark commands below instead.
 
-```bash
-python solutions.py \
---source videos/shortened_enterance.mp4 \
---solution object_counter heatmap
+## Reproducing Tracking Results
+
+The main wrapper is [scripts/run_experiment.sh](scripts/run_experiment.sh). It writes MOT-format predictions to:
+
+```text
+results/paper/<DATASET>-<SPLIT>/<TRACKER>__input_<SIZE>__conf_<CONF>__model_<YOLO>/data/<SEQUENCE>.txt
 ```
 
-### Parking Management
+Run a single paper-setting experiment:
 
 ```bash
-python solutions.py \
---source videos/parking.mp4 \
---solution parking_management
+bash scripts/run_experiment.sh \
+  -d MOT20 \
+  -s train \
+  -t LITEStrongSORT \
+  -m yolov8m \
+  -r 1280 \
+  -c 0.25 \
+  -o results/paper
 ```
 
----
+Run all MOT17/MOT20 trackers used in the table:
+
+```bash
+for dataset in MOT17 MOT20; do
+  for tracker in DeepSORT StrongSORT DeepOCSORT BoTSORT LITEDeepSORT LITEStrongSORT LITEDeepOCSORT LITEBoTSORT; do
+    bash scripts/run_experiment.sh \
+      -d "$dataset" \
+      -s train \
+      -t "$tracker" \
+      -m yolov8m \
+      -r 1280 \
+      -c 0.25 \
+      -o results/paper
+  done
+done
+```
+
+Equivalent direct command for LITE-DeepSORT:
+
+```bash
+python run.py \
+  --dataset MOT20 \
+  --split train \
+  --tracker_name LITEDeepSORT \
+  --input_resolution 1280 \
+  --min_confidence 0.25 \
+  --appearance_feature_layer layer14 \
+  --yolo_model yolov8m \
+  --dir_save results/paper/MOT20-train/LITEDeepSORT__input_1280__conf_0.25__model_yolov8m
+```
+
+For BoT-SORT and Deep OC-SORT variants, the wrapper calls `yolo_tracking/tracking/run.py` with the corresponding `--tracking-method` and optional `--appearance-feature-layer layer14`.
+
+## Evaluating HOTA, CLEAR, and IDF1
+
+Evaluate one dataset split with TrackEval:
+
+```bash
+python TrackEval/scripts/run_mot_challenge.py \
+  --BENCHMARK MOT20 \
+  --SPLIT_TO_EVAL train \
+  --TRACKERS_FOLDER results/paper/MOT20-train \
+  --GT_FOLDER datasets/MOT20/train \
+  --GT_LOC_FORMAT "{gt_folder}/{seq}/gt/gt.txt" \
+  --METRICS HOTA CLEAR Identity VACE \
+  --USE_PARALLEL True \
+  --NUM_PARALLEL_CORES 8 \
+  --OUTPUT_SUMMARY True \
+  --OUTPUT_DETAILED True \
+  --PLOT_CURVES True
+```
+
+For MOT17, replace `MOT20` with `MOT17` and use `results/paper/MOT17-train` plus `datasets/MOT17/train`.
+
+TrackEval writes summary files inside each tracker result directory. Use the `HOTA`, `MOTA`, and `IDF1` columns from those summaries when comparing with the paper table.
+
+## Measuring FPS
+
+The benchmark commands print per-sequence speed and write `fps.csv` for the `run.py` based trackers. For a controlled FPS comparison, keep the same GPU, CUDA version, image size, confidence threshold, batch behavior, and visualization setting across all trackers.
+
+Example single-sequence FPS run:
+
+```bash
+bash scripts/fps.sh -d MOT20 -s train -q MOT20-01
+```
+
+FPS outputs are saved below:
+
+```text
+results/<DATASET>-FPS/<SEQUENCE>/<TRACKER>__input_1280__conf_.25/fps.csv
+```
+
+## ReID Feature Evaluation
+
+Run the ReID evaluator on one sequence:
+
+```bash
+python reid.py \
+  --dataset MOT20 \
+  --seq_name MOT20-01 \
+  --split train \
+  --tracker LITE \
+  --appearance_feature_layer layer14 \
+  --output_path reid_results/MOT20-01 \
+  --save
+```
+
+Run all LITE layers:
+
+```bash
+bash scripts/run_reid_all_layers.sh
+```
+
+The evaluator saves ROC and similarity-distribution plots under the selected `--output_path`.
+
+## Demo Videos and Solutions
+
+Download extra demo videos:
+
+```bash
+bash demo/download_solutions_demo_videos.sh
+```
+
+Run object counting and heatmap demos:
+
+```bash
+python solutions.py --source videos/shortened_enterance.mp4 --solution object_counter
+python solutions.py --source videos/shortened_enterance.mp4 --solution heatmap
+```
+
+Run parking management:
+
+```bash
+python solutions.py --source videos/parking.mp4 --solution parking_management
+```
+
+Outputs are written to `demo_output_videos/`.
+
+## Troubleshooting
+
+- `ModuleNotFoundError` for local modules: run `export PYTHONPATH="$PWD:$PWD/yolo_tracking:$PYTHONPATH"` from the repository root.
+- CUDA or `faiss-gpu` installation errors: install a PyTorch/CUDA combination supported by your driver, or use a CUDA-enabled conda environment.
+- Missing `TrackEval`: clone TrackEval into the repository root or update the evaluation command path.
+- Missing dataset sequence: verify the exact folder names in `datasets/<DATASET>/<split>/`; MOT17 uses names such as `MOT17-02-FRCNN`.
+- GUI/OpenCV errors on a server: use non-demo benchmark commands or configure a virtual display.
 
 ## Citation
 
-If you use LITE in your research, please cite our work:
-
 ```bibtex
 @misc{alikhanov2024liteparadigmshiftmultiobject,
-      title={LITE: A Paradigm Shift in Multi-Object Tracking with Efficient ReID Feature Integration}, 
-      author={Jumabek Alikhanov and Dilshod Obidov and Hakil Kim},
-      year={2024},
-      eprint={2409.04187},
-      archivePrefix={arXiv},
-      primaryClass={cs.CV},
-      url={https://arxiv.org/abs/2409.04187}, 
+  title={LITE: A Paradigm Shift in Multi-Object Tracking with Efficient ReID Feature Integration},
+  author={Jumabek Alikhanov and Dilshod Obidov and Hakil Kim},
+  year={2024},
+  eprint={2409.04187},
+  archivePrefix={arXiv},
+  primaryClass={cs.CV},
+  url={https://arxiv.org/abs/2409.04187}
 }
 ```
 
 ```bibtex
 @ARTICLE{10883969,
   author={Alikhanov, Jumabek and Obidov, Dilshod and Abdurasulov, Mirsaid and Kim, Hakil},
-  journal={IEEE Access}, 
-  title={Practical Evaluation Framework for Real-Time Multi-Object Tracking: Achieving Optimal and Realistic Performance}, 
+  journal={IEEE Access},
+  title={Practical Evaluation Framework for Real-Time Multi-Object Tracking: Achieving Optimal and Realistic Performance},
   year={2025},
   volume={13},
-  number={},
   pages={34768-34788},
-  keywords={Tracking;Detectors;Pipelines;Training;Benchmark testing;Image edge detection;Feature extraction;Real-time systems;Cameras;Performance evaluation;Multiple object tracking (MOT);real-time tracking;evaluation framework;LITE;ReID},
-  doi={10.1109/ACCESS.2025.3541177}}
+  doi={10.1109/ACCESS.2025.3541177}
+}
 ```
-

--- a/demo/README.MD
+++ b/demo/README.MD
@@ -1,6 +1,37 @@
+# Demo Reproduction
 
-# Download video files
-Before running different solutions demo, download relavant videos by 
-`bash demo/download_solutions_demo_videos.sh`
+This folder contains a small VIRAT-S video that can be used as a smoke test after installing the repository dependencies from the root [README.md](../README.md).
 
-![alt text](../assets/image.png)
+## Basic LITE Tracking Demo
+
+Run from the repository root:
+
+```bash
+python demo.py --source demo/VIRAT_S_010204_07_000942_000989.mp4
+```
+
+The script opens an OpenCV window and displays LITE tracking results. Press `q` to stop. The demo uses `yolo11m.pt`; Ultralytics downloads the weight automatically if it is not already available.
+
+## Solution Demo Videos
+
+Some solution demos use larger videos that are not stored directly in the repository. Download them with:
+
+```bash
+bash demo/download_solutions_demo_videos.sh
+```
+
+Then run from the repository root:
+
+```bash
+python solutions.py --source videos/shortened_enterance.mp4 --solution object_counter
+python solutions.py --source videos/shortened_enterance.mp4 --solution heatmap
+python solutions.py --source videos/parking.mp4 --solution parking_management
+```
+
+Generated videos are saved to:
+
+```text
+demo_output_videos/
+```
+
+![Demo preview](../assets/image.png)

--- a/reid_modules/deepsort.py
+++ b/reid_modules/deepsort.py
@@ -139,6 +139,7 @@ class DeepSORTApperanceExtractor(object):
         state_dict = torch.load(model_path, map_location=lambda storage, loc: storage)[
             'net_dict']
         self.net.load_state_dict(state_dict)
+        self.net.eval()
         logger = logging.getLogger("root.tracker")
         logger.debug("Loading weights from {}... Done!".format(model_path))
         self.net.to(self.device)
@@ -179,6 +180,7 @@ class DeepSORTApperanceExtractorOriginal(object):
         state_dict = torch.load(model_path, map_location=lambda storage, loc: storage)[
             'net_dict']
         self.net.load_state_dict(state_dict)
+        self.net.eval()
         logger = logging.getLogger("root.tracker")
         logger.info("Loading weights from {}... Done!".format(model_path))
         self.net.to(self.device)

--- a/reid_modules/strongsort.py
+++ b/reid_modules/strongsort.py
@@ -26,6 +26,7 @@ class StrongSORT:
         cfg.MODEL.WEIGHTS = model_weights
         model = build_model(cfg)
         #model.heads = build_heads(cfg, model.backbone.output_shape())
+        model.to(self.device)
         model.eval()
         Checkpointer(model).load(cfg.MODEL.WEIGHTS)
 
@@ -51,8 +52,9 @@ class StrongSORT:
         ]
 
         for i in range(0, len(crops), self.batch_size):
-            batch = torch.stack(crops[i:i + self.batch_size]).cuda()
-            features = self.model(batch).detach().cpu().numpy()
+            batch = torch.stack(crops[i:i + self.batch_size]).to(self.device)
+            with torch.no_grad():
+                features = self.model(batch).detach().cpu().numpy()
             features_list.extend(features)
 
         return features_list

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ gitpython==3.1.43
 ipykernel==6.29.5
 lapx==0.5.10.post1
 loguru==0.7.2
+numpy<2
 opencv-python==4.10.0.84
 openpyxl==3.1.5
 albumentations

--- a/scripts/crop_similarity.py
+++ b/scripts/crop_similarity.py
@@ -1,0 +1,423 @@
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def load_class_from_file(module_name, path, class_name):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, class_name)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Compare crop images with StrongSORT and LITEStrongSORT ReID features."
+    )
+    parser.add_argument(
+        "crops",
+        type=Path,
+        nargs="+",
+        help=(
+            "Crop images. For --mode identity4, pass: "
+            "id1_frame1 id1_frame10 id2_frame1 id2_frame10."
+        ),
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["auto", "query", "identity4"],
+        default="auto",
+        help=(
+            "Comparison mode. 'identity4' computes positive and negative ReID matches "
+            "from four crops; 'query' compares crop 0 to every later crop."
+        ),
+    )
+    parser.add_argument(
+        "--device",
+        default="auto",
+        help="Torch device for feature extraction. Use 'auto' to prefer cuda:0 when available.",
+    )
+    parser.add_argument(
+        "--yolo_model",
+        default="yolov8m.pt",
+        help="YOLO checkpoint used by LITEStrongSORT. Examples: yolov8m.pt, yolo11m.pt.",
+    )
+    parser.add_argument(
+        "--appearance_feature_layer",
+        default="layer14",
+        help="YOLO feature layer used by LITEStrongSORT.",
+    )
+    parser.add_argument(
+        "--imgsz",
+        type=int,
+        default=1280,
+        help="LITEStrongSORT YOLO inference image size.",
+    )
+    parser.add_argument(
+        "--conf",
+        type=float,
+        default=0.25,
+        help="LITEStrongSORT YOLO confidence threshold.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of a text table.",
+    )
+    parser.add_argument(
+        "--plot",
+        type=Path,
+        help="Optional path to save a comparison figure, e.g. outputs/crop_similarity.png.",
+    )
+    return parser.parse_args()
+
+
+def read_crop(path):
+    import cv2
+
+    image = cv2.imread(str(path), cv2.IMREAD_COLOR)
+    if image is None:
+        raise FileNotFoundError(f"Could not read crop image: {path}")
+    return image
+
+
+def full_image_box(image):
+    import numpy as np
+
+    height, width = image.shape[:2]
+    return np.array([[0, 0, width, height]], dtype=np.float32)
+
+
+def extract_one(reid_model, image):
+    import numpy as np
+
+    try:
+        features = reid_model.extract_appearance_features(image, full_image_box(image))
+    except SyntaxError as exc:
+        message = str(exc)
+        if "appearance_feature_layer" in message or "return_feature_map" in message:
+            raise RuntimeError(
+                "LITEStrongSORT needs the custom LITE Ultralytics fork. "
+                "Install it from https://github.com/Jumabek/ultralytics.git "
+                "or make that checkout importable before running this script."
+            ) from exc
+        raise
+    if len(features) == 0:
+        raise RuntimeError("Feature extractor returned no features.")
+    return np.asarray(features[0], dtype=np.float32).reshape(-1)
+
+
+def l2_normalize(feature):
+    import numpy as np
+
+    norm = np.linalg.norm(feature)
+    if norm == 0:
+        raise RuntimeError("Cannot compute cosine similarity for a zero vector.")
+    return feature / norm
+
+
+def cosine_similarity(feature_a, feature_b):
+    import numpy as np
+
+    if feature_a.shape != feature_b.shape:
+        return None
+    feature_a = l2_normalize(feature_a)
+    feature_b = l2_normalize(feature_b)
+    return float(np.dot(feature_a, feature_b))
+
+
+def score_row(model, match_type, pair_label, path_a, path_b, feature_a, feature_b):
+    score = cosine_similarity(feature_a, feature_b)
+    return {
+        "model": model,
+        "match_type": match_type,
+        "pair": pair_label,
+        "crop_a": str(path_a),
+        "crop_b": str(path_b),
+        "similarity": score,
+        "feature_a_dim": int(feature_a.shape[0]),
+        "feature_b_dim": int(feature_b.shape[0]),
+    }
+
+
+def print_text(rows):
+    import statistics
+
+    print("model             type       pair                         similarity    dims")
+    print("-" * 82)
+    for row in rows:
+        score = f"{row['similarity']:.6f}"
+        dims = f"{row['feature_a_dim']} x {row['feature_b_dim']}"
+        print(
+            f"{row['model']:<17} {row['match_type']:<10} "
+            f"{row['pair']:<28} {score:>10}    {dims}"
+        )
+
+    print()
+    print("model             positive_mean    negative_mean    margin")
+    print("-" * 62)
+    models = []
+    for row in rows:
+        if row["model"] not in models:
+            models.append(row["model"])
+    for model in models:
+        model_rows = [row for row in rows if row["model"] == model]
+        positives = [row["similarity"] for row in model_rows if row["match_type"] == "positive"]
+        negatives = [row["similarity"] for row in model_rows if row["match_type"] == "negative"]
+        if positives and negatives:
+            pos_mean = statistics.mean(positives)
+            neg_mean = statistics.mean(negatives)
+            margin = pos_mean - neg_mean
+            print(f"{model:<17} {pos_mean:>13.6f} {neg_mean:>16.6f} {margin:>9.6f}")
+
+
+def get_query_specs(crop_paths):
+    return [
+        ("candidate", f"{Path(crop_paths[0]).name} vs {Path(crop_paths[index]).name}", 0, index)
+        for index in range(1, len(crop_paths))
+    ]
+
+
+def get_identity4_specs():
+    return [
+        ("positive", "id1 frame1 vs frame10", 0, 1),
+        ("positive", "id2 frame1 vs frame10", 2, 3),
+        ("negative", "id1 f1 vs id2 f1", 0, 2),
+        ("negative", "id1 f1 vs id2 f10", 0, 3),
+        ("negative", "id1 f10 vs id2 f1", 1, 2),
+        ("negative", "id1 f10 vs id2 f10", 1, 3),
+    ]
+
+
+def build_rows_by_model(features, crop_paths, pair_specs):
+    rows_by_model = {}
+    for model, model_features in features.items():
+        rows_by_model[model] = [
+            score_row(
+                model,
+                match_type,
+                pair_label,
+                crop_paths[index_a],
+                crop_paths[index_b],
+                model_features[index_a],
+                model_features[index_b],
+            )
+            for match_type, pair_label, index_a, index_b in pair_specs
+        ]
+    return rows_by_model
+
+
+def save_plot(rows_by_model, crop_paths, output_path):
+    import cv2
+    import matplotlib.pyplot as plt
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    rgb_images = []
+    for path in crop_paths:
+        image = cv2.imread(str(path), cv2.IMREAD_COLOR)
+        if image is None:
+            raise FileNotFoundError(f"Could not read crop image: {path}")
+        rgb_images.append(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
+
+    models = list(rows_by_model.keys())
+    columns = len(crop_paths)
+    fig, axes = plt.subplots(
+        len(models),
+        columns,
+        figsize=(max(8, columns * 2.2), max(4, len(models) * 3.2)),
+        squeeze=False,
+    )
+
+    for row_idx, model in enumerate(models):
+        model_rows = rows_by_model[model]
+        scores_by_candidate = {
+            Path(row["crop_b"]): row["similarity"]
+            for row in model_rows
+        }
+        for col_idx, (path, image) in enumerate(zip(crop_paths, rgb_images)):
+            ax = axes[row_idx][col_idx]
+            ax.imshow(image)
+            ax.set_xticks([])
+            ax.set_yticks([])
+            if col_idx == 0:
+                ax.set_title(f"{model}\nquery", fontsize=12, fontweight="bold")
+                for spine in ax.spines.values():
+                    spine.set_visible(True)
+                    spine.set_linewidth(4)
+                    spine.set_edgecolor("#bf5af2")
+            else:
+                score = scores_by_candidate[path]
+                ax.set_title(f"{Path(path).name}\nscore={score:.4f}", fontsize=10)
+                color = "#6bd34a" if score >= 0.5 else "#ff3b30"
+                for spine in ax.spines.values():
+                    spine.set_visible(True)
+                    spine.set_linewidth(4)
+                    spine.set_edgecolor(color)
+
+        axes[row_idx][0].set_ylabel(model, fontsize=13, fontweight="bold", rotation=90)
+
+    fig.suptitle("Crop Similarity: Query vs Candidate Crops", fontsize=16, fontweight="bold")
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=180)
+    plt.close(fig)
+
+
+def save_identity_plot(rows_by_model, crop_paths, pair_specs, output_path):
+    import cv2
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    rgb_images = []
+    for path in crop_paths:
+        image = cv2.imread(str(path), cv2.IMREAD_COLOR)
+        if image is None:
+            raise FileNotFoundError(f"Could not read crop image: {path}")
+        rgb_images.append(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
+
+    def fit_image(image, height=170, width=95):
+        src_h, src_w = image.shape[:2]
+        scale = min(width / src_w, height / src_h)
+        resized = cv2.resize(image, (max(1, int(src_w * scale)), max(1, int(src_h * scale))))
+        canvas = np.full((height, width, 3), 255, dtype=np.uint8)
+        y = (height - resized.shape[0]) // 2
+        x = (width - resized.shape[1]) // 2
+        canvas[y:y + resized.shape[0], x:x + resized.shape[1]] = resized
+        return canvas
+
+    def pair_card(image_a, image_b):
+        left = fit_image(image_a)
+        right = fit_image(image_b)
+        gap = np.full((170, 38, 3), 255, dtype=np.uint8)
+        cv2.putText(gap, "vs", (4, 92), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 0), 2)
+        return np.concatenate([left, gap, right], axis=1)
+
+    models = list(rows_by_model.keys())
+    columns = len(pair_specs)
+    fig, axes = plt.subplots(
+        len(models),
+        columns,
+        figsize=(max(16, columns * 2.8), max(6, len(models) * 3.4)),
+        squeeze=False,
+    )
+
+    for row_idx, model in enumerate(models):
+        for col_idx, ((match_type, pair_label, index_a, index_b), row) in enumerate(
+            zip(pair_specs, rows_by_model[model])
+        ):
+            ax = axes[row_idx][col_idx]
+            ax.imshow(pair_card(rgb_images[index_a], rgb_images[index_b]))
+            ax.set_xticks([])
+            ax.set_yticks([])
+            ax.set_title(f"{pair_label}\nscore={row['similarity']:.4f}", fontsize=10)
+
+            color = "#6bd34a" if match_type == "positive" else "#ff3b30"
+            for spine in ax.spines.values():
+                spine.set_visible(True)
+                spine.set_linewidth(4)
+                spine.set_edgecolor(color)
+
+            if row_idx == 0:
+                ax.text(
+                    0.5,
+                    1.24,
+                    match_type.title(),
+                    transform=ax.transAxes,
+                    ha="center",
+                    va="bottom",
+                    fontsize=13,
+                    fontweight="bold",
+                    color=color,
+                )
+            if col_idx == 0:
+                ax.set_ylabel(model, fontsize=14, fontweight="bold")
+
+    fig.suptitle(
+        "Positive vs Negative ReID Similarities by Tracker",
+        fontsize=18,
+        fontweight="bold",
+    )
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=180)
+    plt.close(fig)
+
+
+def main():
+    args = parse_args()
+
+    import torch
+    from ultralytics import YOLO
+
+    StrongSORT = load_class_from_file(
+        "crop_similarity_strongsort",
+        ROOT / "reid_modules" / "strongsort.py",
+        "StrongSORT",
+    )
+    LITE = load_class_from_file(
+        "crop_similarity_lite",
+        ROOT / "reid_modules" / "lite.py",
+        "LITE",
+    )
+
+    device = args.device
+    if device == "auto":
+        device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+    mode = args.mode
+    if mode == "auto":
+        mode = "identity4" if len(args.crops) == 4 else "query"
+
+    if mode == "identity4" and len(args.crops) != 4:
+        raise ValueError(
+            "--mode identity4 needs exactly four crop paths: "
+            "id1_frame1 id1_frame10 id2_frame1 id2_frame10."
+        )
+    if mode == "query" and len(args.crops) < 2:
+        raise ValueError("Provide at least two crop paths: query crop plus one candidate crop.")
+
+    crop_images = [read_crop(path) for path in args.crops]
+
+    strongsort = StrongSORT(device=device)
+    yolo = YOLO(args.yolo_model)
+    yolo.to(device)
+    lite_strongsort = LITE(
+        model=yolo,
+        appearance_feature_layer=args.appearance_feature_layer,
+        imgsz=args.imgsz,
+        conf=args.conf,
+        device=device,
+    )
+
+    features = {
+        "StrongSORT": [extract_one(strongsort, image) for image in crop_images],
+        "LITEStrongSORT": [extract_one(lite_strongsort, image) for image in crop_images],
+    }
+
+    pair_specs = get_identity4_specs() if mode == "identity4" else get_query_specs(args.crops)
+    rows_by_model = build_rows_by_model(features, args.crops, pair_specs)
+
+    rows = [row for model_rows in rows_by_model.values() for row in model_rows]
+
+    if args.plot:
+        if mode == "identity4":
+            save_identity_plot(rows_by_model, args.crops, pair_specs, args.plot)
+        else:
+            save_plot(rows_by_model, args.crops, args.plot)
+
+    if args.json:
+        print(json.dumps(rows, indent=2))
+    else:
+        print_text(rows)
+        if args.plot:
+            print()
+            print(f"Saved plot: {args.plot}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/crop_similarity.py
+++ b/scripts/crop_similarity.py
@@ -66,6 +66,13 @@ def parse_args():
         help="LITEStrongSORT YOLO confidence threshold.",
     )
     parser.add_argument(
+        "--models",
+        nargs="+",
+        default=["StrongSORT", "DeepSORT", "OSNet", "LITE"],
+        choices=["StrongSORT", "DeepSORT", "OSNet", "LITE"],
+        help="ReID models to compare.",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Print machine-readable JSON instead of a text table.",
@@ -186,12 +193,10 @@ def get_query_specs(crop_paths):
 
 def get_identity4_specs():
     return [
-        ("positive", "id1 frame1 vs frame10", 0, 1),
-        ("positive", "id2 frame1 vs frame10", 2, 3),
-        ("negative", "id1 f1 vs id2 f1", 0, 2),
-        ("negative", "id1 f1 vs id2 f10", 0, 3),
-        ("negative", "id1 f10 vs id2 f1", 1, 2),
-        ("negative", "id1 f10 vs id2 f10", 1, 3),
+        ("positive", "ID 1: Frame 1 vs Frame 10", 0, 1),
+        ("positive", "ID 2: Frame 1 vs Frame 10", 2, 3),
+        ("negative", "Frame 1: ID 1 vs ID 2", 0, 2),
+        ("negative", "Frame 10: ID 1 vs ID 2", 1, 3),
     ]
 
 
@@ -211,6 +216,53 @@ def build_rows_by_model(features, crop_paths, pair_specs):
             for match_type, pair_label, index_a, index_b in pair_specs
         ]
     return rows_by_model
+
+
+def load_reid_models(model_names, device, yolo_model, appearance_feature_layer, imgsz, conf):
+    from ultralytics import YOLO
+
+    model_classes = {
+        "StrongSORT": load_class_from_file(
+            "crop_similarity_strongsort",
+            ROOT / "reid_modules" / "strongsort.py",
+            "StrongSORT",
+        ),
+        "DeepSORT": load_class_from_file(
+            "crop_similarity_deepsort",
+            ROOT / "reid_modules" / "deepsort.py",
+            "DeepSORT",
+        ),
+        "OSNet": load_class_from_file(
+            "crop_similarity_osnet",
+            ROOT / "reid_modules" / "osnet.py",
+            "OSNet",
+        ),
+        "LITE": load_class_from_file(
+            "crop_similarity_lite",
+            ROOT / "reid_modules" / "lite.py",
+            "LITE",
+        ),
+    }
+
+    reid_models = {}
+    if "StrongSORT" in model_names:
+        reid_models["StrongSORT"] = model_classes["StrongSORT"](device=device)
+    if "DeepSORT" in model_names:
+        reid_models["DeepSORT"] = model_classes["DeepSORT"](device=device)
+    if "OSNet" in model_names:
+        reid_models["OSNet"] = model_classes["OSNet"](device=device)
+    if "LITE" in model_names:
+        yolo = YOLO(yolo_model)
+        yolo.to(device)
+        reid_models["LITE"] = model_classes["LITE"](
+            model=yolo,
+            appearance_feature_layer=appearance_feature_layer,
+            imgsz=imgsz,
+            conf=conf,
+            device=device,
+        )
+
+    return reid_models
 
 
 def save_plot(rows_by_model, crop_paths, output_path):
@@ -264,11 +316,11 @@ def save_plot(rows_by_model, crop_paths, output_path):
 
     fig.suptitle("Crop Similarity: Query vs Candidate Crops", fontsize=16, fontweight="bold")
     fig.tight_layout()
-    fig.savefig(output_path, dpi=180)
+    fig.savefig(output_path, dpi=300)
     plt.close(fig)
 
 
-def save_identity_plot(rows_by_model, crop_paths, pair_specs, output_path):
+def save_identity_plots(rows_by_model, crop_paths, pair_specs, output_path):
     import cv2
     import numpy as np
     import matplotlib.pyplot as plt
@@ -281,7 +333,7 @@ def save_identity_plot(rows_by_model, crop_paths, pair_specs, output_path):
             raise FileNotFoundError(f"Could not read crop image: {path}")
         rgb_images.append(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
 
-    def fit_image(image, height=170, width=95):
+    def fit_image(image, height=150, width=84):
         src_h, src_w = image.shape[:2]
         scale = min(width / src_w, height / src_h)
         resized = cv2.resize(image, (max(1, int(src_w * scale)), max(1, int(src_h * scale))))
@@ -291,79 +343,99 @@ def save_identity_plot(rows_by_model, crop_paths, pair_specs, output_path):
         canvas[y:y + resized.shape[0], x:x + resized.shape[1]] = resized
         return canvas
 
-    def pair_card(image_a, image_b):
+    def pair_card(image_a, image_b, score):
         left = fit_image(image_a)
         right = fit_image(image_b)
-        gap = np.full((170, 38, 3), 255, dtype=np.uint8)
-        cv2.putText(gap, "vs", (4, 92), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 0), 2)
+        gap = np.full((left.shape[0], 54, 3), 255, dtype=np.uint8)
+        score_text = f"{score:.3f}"
+        font = cv2.FONT_HERSHEY_SIMPLEX
+        font_scale = 0.55
+        thickness = 2
+        text_size, _ = cv2.getTextSize(score_text, font, font_scale, thickness)
+        text_x = (gap.shape[1] - text_size[0]) // 2
+        text_y = (gap.shape[0] + text_size[1]) // 2
+        cv2.putText(gap, score_text, (text_x, text_y), font, font_scale, (0, 0, 0), thickness)
         return np.concatenate([left, gap, right], axis=1)
 
     models = list(rows_by_model.keys())
-    columns = len(pair_specs)
-    fig, axes = plt.subplots(
-        len(models),
-        columns,
-        figsize=(max(16, columns * 2.8), max(6, len(models) * 3.4)),
-        squeeze=False,
-    )
+    outputs = []
+    plot_configs = [
+        (
+            "positive",
+            "Positive Matches",
+            "Same identity across Frame 1 and Frame 10",
+            "#6bd34a",
+            output_path.with_name(f"{output_path.stem}_positive_matches{output_path.suffix}"),
+        ),
+        (
+            "negative",
+            "Negative Matches",
+            "Different identities in the same frame",
+            "#ff3b30",
+            output_path.with_name(f"{output_path.stem}_negative_matches{output_path.suffix}"),
+        ),
+    ]
 
-    for row_idx, model in enumerate(models):
-        for col_idx, ((match_type, pair_label, index_a, index_b), row) in enumerate(
-            zip(pair_specs, rows_by_model[model])
-        ):
-            ax = axes[row_idx][col_idx]
-            ax.imshow(pair_card(rgb_images[index_a], rgb_images[index_b]))
-            ax.set_xticks([])
-            ax.set_yticks([])
-            ax.set_title(f"{pair_label}\nscore={row['similarity']:.4f}", fontsize=10)
+    for match_type, title, subtitle, color, split_output_path in plot_configs:
+        filtered_specs = [
+            spec for spec in pair_specs
+            if spec[0] == match_type
+        ]
+        columns = len(filtered_specs)
+        row_height = 1.22
+        column_width = 1.86
+        fig, axes = plt.subplots(
+            len(models),
+            columns,
+            figsize=(max(3.35, columns * column_width), max(4.25, len(models) * row_height)),
+            squeeze=False,
+        )
+        for row_idx, model in enumerate(models):
+            model_rows = [
+                row for row in rows_by_model[model]
+                if row["match_type"] == match_type
+            ]
+            for col_idx, ((_, pair_label, index_a, index_b), row) in enumerate(
+                zip(filtered_specs, model_rows)
+            ):
+                ax = axes[row_idx][col_idx]
+                ax.imshow(pair_card(rgb_images[index_a], rgb_images[index_b], row["similarity"]))
+                ax.set_xticks([])
+                ax.set_yticks([])
+                if row_idx == 0:
+                    ax.set_title(f"Pair {col_idx + 1}", fontsize=8, pad=3)
 
-            color = "#6bd34a" if match_type == "positive" else "#ff3b30"
-            for spine in ax.spines.values():
-                spine.set_visible(True)
-                spine.set_linewidth(4)
-                spine.set_edgecolor(color)
+                for spine in ax.spines.values():
+                    spine.set_visible(True)
+                    spine.set_linewidth(2.5)
+                    spine.set_edgecolor(color)
 
-            if row_idx == 0:
-                ax.text(
-                    0.5,
-                    1.24,
-                    match_type.title(),
-                    transform=ax.transAxes,
-                    ha="center",
-                    va="bottom",
-                    fontsize=13,
-                    fontweight="bold",
-                    color=color,
-                )
-            if col_idx == 0:
-                ax.set_ylabel(model, fontsize=14, fontweight="bold")
+                if col_idx == 0:
+                    ax.set_ylabel(
+                        model,
+                        fontsize=8.5,
+                        fontweight="bold",
+                        rotation=0,
+                        ha="right",
+                        va="center",
+                        labelpad=20,
+                    )
 
-    fig.suptitle(
-        "Positive vs Negative ReID Similarities by Tracker",
-        fontsize=18,
-        fontweight="bold",
-    )
-    fig.tight_layout()
-    fig.savefig(output_path, dpi=180)
-    plt.close(fig)
+        fig.suptitle(title, fontsize=11, fontweight="bold", y=0.99)
+        fig.text(0.5, 0.95, subtitle, ha="center", va="top", fontsize=8.5)
+        fig.tight_layout(rect=(0.02, 0.02, 0.98, 0.998))
+        fig.subplots_adjust(hspace=0.02, wspace=0.01)
+        fig.savefig(split_output_path, dpi=220, bbox_inches="tight", pad_inches=0.08)
+        plt.close(fig)
+        outputs.append(split_output_path)
+
+    return outputs
 
 
 def main():
     args = parse_args()
 
     import torch
-    from ultralytics import YOLO
-
-    StrongSORT = load_class_from_file(
-        "crop_similarity_strongsort",
-        ROOT / "reid_modules" / "strongsort.py",
-        "StrongSORT",
-    )
-    LITE = load_class_from_file(
-        "crop_similarity_lite",
-        ROOT / "reid_modules" / "lite.py",
-        "LITE",
-    )
 
     device = args.device
     if device == "auto":
@@ -383,20 +455,18 @@ def main():
 
     crop_images = [read_crop(path) for path in args.crops]
 
-    strongsort = StrongSORT(device=device)
-    yolo = YOLO(args.yolo_model)
-    yolo.to(device)
-    lite_strongsort = LITE(
-        model=yolo,
-        appearance_feature_layer=args.appearance_feature_layer,
-        imgsz=args.imgsz,
-        conf=args.conf,
-        device=device,
+    reid_models = load_reid_models(
+        args.models,
+        device,
+        args.yolo_model,
+        args.appearance_feature_layer,
+        args.imgsz,
+        args.conf,
     )
 
     features = {
-        "StrongSORT": [extract_one(strongsort, image) for image in crop_images],
-        "LITEStrongSORT": [extract_one(lite_strongsort, image) for image in crop_images],
+        model_name: [extract_one(reid_model, image) for image in crop_images]
+        for model_name, reid_model in reid_models.items()
     }
 
     pair_specs = get_identity4_specs() if mode == "identity4" else get_query_specs(args.crops)
@@ -404,19 +474,22 @@ def main():
 
     rows = [row for model_rows in rows_by_model.values() for row in model_rows]
 
+    saved_plots = []
     if args.plot:
         if mode == "identity4":
-            save_identity_plot(rows_by_model, args.crops, pair_specs, args.plot)
+            saved_plots = save_identity_plots(rows_by_model, args.crops, pair_specs, args.plot)
         else:
             save_plot(rows_by_model, args.crops, args.plot)
+            saved_plots = [args.plot]
 
     if args.json:
         print(json.dumps(rows, indent=2))
     else:
         print_text(rows)
-        if args.plot:
+        if saved_plots:
             print()
-            print(f"Saved plot: {args.plot}")
+            for saved_plot in saved_plots:
+                print(f"Saved plot: {saved_plot}")
 
 
 if __name__ == "__main__":

--- a/scripts/run_experiment.sh
+++ b/scripts/run_experiment.sh
@@ -1,138 +1,108 @@
 #!/bin/bash
+set -euo pipefail
 
-# Resolutions and other constants
-INPUT_RESOLUTIONS=(1280)
-<<<<<<< Updated upstream
-CONFIDENCE_LEVELS=(0.25)
-DATASETS=("MOT20")
+DATASET="MOT20"
 SPLIT="train"
-MODELS=('yolov8m')
+TRACKER="LITEStrongSORT"
+YOLO_MODEL="yolov8m"
+INPUT_RESOLUTION="1280"
+CONFIDENCE="0.25"
+DIR_ROOT="results/paper"
 
-=======
-CONFIDENCE_LEVELS=(0.01)
-DATASETS=("MOT20")
-SPLIT="train"
-MODELS=('yolov8m')
->>>>>>> Stashed changes
-
-#n' 'ablation_17s
 usage() {
-    echo "Usage: $0 -s SPLIT"
-    echo "  -s SPLIT     Split (e.g., train)"
-    exit 1
+    local status="${1:-1}"
+    echo "Usage: $0 [-d DATASET] [-s SPLIT] [-t TRACKER] [-m YOLO_MODEL] [-r INPUT_RESOLUTION] [-c CONFIDENCE] [-o DIR_ROOT]"
+    echo "  -d DATASET           Dataset name, e.g. MOT17 or MOT20 (default: ${DATASET})"
+    echo "  -s SPLIT             Split, e.g. train or test (default: ${SPLIT})"
+    echo "  -t TRACKER           Tracker name (default: ${TRACKER})"
+    echo "  -m YOLO_MODEL        YOLO model stem, e.g. yolov8m or yolo11m (default: ${YOLO_MODEL})"
+    echo "  -r INPUT_RESOLUTION  Input image size (default: ${INPUT_RESOLUTION})"
+    echo "  -c CONFIDENCE        Detection confidence threshold (default: ${CONFIDENCE})"
+    echo "  -o DIR_ROOT          Output root directory (default: ${DIR_ROOT})"
+    echo
+    echo "Tracker options: SORT, LITEDeepSORT, DeepSORT, StrongSORT, LITEStrongSORT,"
+    echo "                 OCSORT, Bytetrack, DeepOCSORT, LITEDeepOCSORT, BoTSORT, LITEBoTSORT"
+    exit "${status}"
 }
 
-# Parse command-line options
-while getopts "s:" opt; do
-    case ${opt} in
-        s)
-            SPLIT=${OPTARG}
-            ;;
-        \?)
-            usage
-            ;;
+while getopts "d:s:t:m:r:c:o:h" opt; do
+    case "${opt}" in
+        d) DATASET=${OPTARG} ;;
+        s) SPLIT=${OPTARG} ;;
+        t) TRACKER=${OPTARG} ;;
+        m) YOLO_MODEL=${OPTARG} ;;
+        r) INPUT_RESOLUTION=${OPTARG} ;;
+        c) CONFIDENCE=${OPTARG} ;;
+        o) DIR_ROOT=${OPTARG} ;;
+        h) usage 0 ;;
+        \?) usage ;;
     esac
 done
-shift $((OPTIND -1))
 
-# Check if mandatory variables are set
-if [ -z "$SPLIT" ]; then
-    echo "Error: Missing required arguments."
-    usage
-fi
+DIR_SAVE="${DIR_ROOT}/${DATASET}-${SPLIT}/${TRACKER}__input_${INPUT_RESOLUTION}__conf_${CONFIDENCE}__model_${YOLO_MODEL}"
+mkdir -p "${DIR_SAVE}"
 
-# Loop through datasets
-for DATASET in "${DATASETS[@]}"
-do
-    for INPUT_RESOLUTION in "${INPUT_RESOLUTIONS[@]}"
-    do
-        for CONFIDENCE in "${CONFIDENCE_LEVELS[@]}"
-        do # chnage to run_parallel.py if you want to run multiple videos in parallel
-           CMD="python3 run.py \
-                    --dataset ${DATASET} \
-                    --split ${SPLIT} \
-                    --input_resolution ${INPUT_RESOLUTION} \
-                    --min_confidence ${CONFIDENCE}"
+CMD=(
+    python3 run.py
+    --dataset "${DATASET}"
+    --split "${SPLIT}"
+    --input_resolution "${INPUT_RESOLUTION}"
+    --min_confidence "${CONFIDENCE}"
+    --dir_save "${DIR_SAVE}"
+    --yolo_model "${YOLO_MODEL}"
+)
 
-            CMD_YOLO_TRACKING="python3 yolo_tracking/tracking/run.py \
-                    --dataset ${DATASET} \
-                    --split ${SPLIT} \
-                    --imgsz ${INPUT_RESOLUTION} \
-                    --conf ${CONFIDENCE}"
-            # print CMD_YOLO_TRACKING
-            echo $CMD
+CMD_YOLO_TRACKING=(
+    python3 yolo_tracking/tracking/run.py
+    --dataset "${DATASET}"
+    --split "${SPLIT}"
+    --imgsz "${INPUT_RESOLUTION}"
+    --conf "${CONFIDENCE}"
+    --project "${DIR_SAVE}"
+    --yolo-model "${YOLO_MODEL}"
+)
 
-            run_tracker() {
-                TRACKER_NAME=$1
-                YOLO_MODEL=$2
-                echo "-----------------------------------"
-                echo "Running tracker: ${TRACKER_NAME} with YOLO model: ${YOLO_MODEL} at confidence: ${CONFIDENCE}"
+echo "Running ${TRACKER} on ${DATASET}-${SPLIT}"
+echo "Output: ${DIR_SAVE}"
 
-<<<<<<< Updated upstream
-                DIR_SAVE="results/fps-exp/${DATASET}-${SPLIT}/${TRACKER_NAME}__input_${INPUT_RESOLUTION}__conf_${CONFIDENCE}__model_${YOLO_MODEL}"
-=======
-                DIR_SAVE="results/exp_conf_0.01/model/${DATASET}-${SPLIT}/${TRACKER_NAME}__input_${INPUT_RESOLUTION}__conf_${CONFIDENCE}__model_${YOLO_MODEL}"
->>>>>>> Stashed changes
-                mkdir -p "${DIR_SAVE}"
+case "${TRACKER}" in
+    "SORT")
+        "${CMD[@]}" --tracker_name "SORT"
+        ;;
+    "LITEDeepSORT")
+        "${CMD[@]}" --tracker_name "LITEDeepSORT" --woC --appearance_feature_layer "layer14"
+        ;;
+    "DeepSORT")
+        "${CMD[@]}" --tracker_name "DeepSORT"
+        ;;
+    "StrongSORT")
+        "${CMD[@]}" --tracker_name "StrongSORT" --BoT --ECC --NSA --EMA --MC --woC
+        ;;
+    "LITEStrongSORT")
+        "${CMD[@]}" --tracker_name "LITEStrongSORT" --BoT --ECC --NSA --EMA --MC --woC --appearance_feature_layer "layer14"
+        ;;
+    "OCSORT")
+        "${CMD_YOLO_TRACKING[@]}" --tracking-method "ocsort"
+        ;;
+    "Bytetrack")
+        "${CMD_YOLO_TRACKING[@]}" --tracking-method "bytetrack"
+        ;;
+    "DeepOCSORT")
+        "${CMD_YOLO_TRACKING[@]}" --tracking-method "deepocsort"
+        ;;
+    "LITEDeepOCSORT")
+        "${CMD_YOLO_TRACKING[@]}" --tracking-method "deepocsort" --appearance-feature-layer "layer14"
+        ;;
+    "BoTSORT")
+        "${CMD_YOLO_TRACKING[@]}" --tracking-method "botsort"
+        ;;
+    "LITEBoTSORT")
+        "${CMD_YOLO_TRACKING[@]}" --tracking-method "botsort" --appearance-feature-layer "layer14"
+        ;;
+    *)
+        echo "Invalid tracker name: ${TRACKER}"
+        usage
+        ;;
+esac
 
-                case ${TRACKER_NAME} in
-                    "SORT")
-                        ${CMD} --tracker_name "SORT" --dir_save ${DIR_SAVE} --yolo_model ${YOLO_MODEL}
-                        ;;
-                    "LITEDeepSORT")
-                        ${CMD} --tracker_name "LITEDeepSORT" --woC --appearance_feature_layer "layer14" --dir_save ${DIR_SAVE} --yolo_model ${YOLO_MODEL}
-                        ;;
-                    "DeepSORT")
-                        ${CMD} --tracker_name "DeepSORT" --dir_save ${DIR_SAVE} --yolo_model ${YOLO_MODEL}
-                        ;;
-                    "StrongSORT")
-                        ${CMD} --tracker_name "StrongSORT" --BoT --ECC --NSA --EMA --MC --woC --dir_save ${DIR_SAVE} --yolo_model ${YOLO_MODEL}
-                        ;;
-                    "LITEStrongSORT")
-                        ${CMD} --tracker_name "LITEStrongSORT" --BoT --ECC --NSA --EMA --MC --woC --dir_save ${DIR_SAVE} --yolo_model ${YOLO_MODEL} --appearance_feature_layer "layer14"
-                        ;;
-                    "OCSORT")
-                        ${CMD_YOLO_TRACKING} --tracking-method "ocsort" --project ${DIR_SAVE}
-                        ;;
-                    "Bytetrack")
-                        ${CMD_YOLO_TRACKING} --tracking-method "bytetrack" --project ${DIR_SAVE}
-                        ;;
-                    "DeepOCSORT")
-                        ${CMD_YOLO_TRACKING} --tracking-method "deepocsort" --project ${DIR_SAVE}
-                        ;;
-                    "LITEDeepOCSORT")
-                        ${CMD_YOLO_TRACKING} --tracking-method "deepocsort" --project ${DIR_SAVE} --appearance-feature-layer "layer14" --yolo-model ${YOLO_MODEL}
-                        ;;
-                    "BoTSORT")
-                        ${CMD_YOLO_TRACKING} --tracking-method "botsort" --project ${DIR_SAVE} --yolo-model ${YOLO_MODEL}
-                        ;;
-                    "LITEBoTSORT")  
-                        ${CMD_YOLO_TRACKING} --tracking-method "botsort" --project ${DIR_SAVE} --appearance-feature-layer "layer14" --yolo-model ${YOLO_MODEL}
-                        ;;
-                    *)
-                        echo "Invalid tracker name"
-                        exit 1
-                        ;;
-                esac
-                echo "Experiment completed for ${TRACKER_NAME} with YOLO model: ${YOLO_MODEL} at confidence: ${CONFIDENCE}!"
-            }
-
-            # Loop through models and trackers
-<<<<<<< Updated upstream
-            TRACKERS=("LITEStrongSORT")
-
-=======
-            #TRACKERS=("SORT" )
-            #TRACKERS=("LITEBoTSORT" "LITEDeepOCSORT")
-            #TRACKERS=('Bytetrack' 'OCSORT' 'LITEDeepSORT' '')
-            #TRACKERS=("DeepOCSORT" "LITEDeepOCSORT" "BoTSORT" "LITEBoTSORT")
-            TRACKERS=("LITEDeepSORT")
->>>>>>> Stashed changes
-            for YOLO_MODEL in "${MODELS[@]}"; do
-                for TRACKER in "${TRACKERS[@]}"; do
-                    run_tracker "${TRACKER}" "${YOLO_MODEL}"
-                done
-            done
-        done
-    done
-done
+echo "Experiment completed."


### PR DESCRIPTION
This pull request updates the documentation and improves code robustness for the LITE multi-object tracking repository. The main changes include a major rewrite and clarification of the `README.md` to provide clearer installation, usage, and evaluation instructions, as well as minor fixes to ReID model initialization and demo instructions. Additionally, the ReID modules are updated to ensure models are set to evaluation mode and tensors are moved to the correct device, which enhances inference reliability.

**Documentation improvements:**

* Completely rewrote `README.md` to provide a clearer, more concise overview of LITE, detailed installation steps, dataset and checkpoint setup, experiment and evaluation commands, troubleshooting tips, and citation instructions. This makes it much easier for new users to get started and reproduce results.
* Added a new `demo/README.MD` with step-by-step instructions for running the included demo video and solution demos, including guidance on downloading required video files and interpreting outputs.

**ReID model robustness:**

* Ensured that the DeepSORT and StrongSORT ReID models are set to evaluation mode (`.eval()`) after loading weights, which prevents issues with batchnorm/dropout during inference. [[1]](diffhunk://#diff-66b4432108d2aa4739cd39a3370da2dc61ca2583ff90cb66ec17c6541735dd57R142) [[2]](diffhunk://#diff-66b4432108d2aa4739cd39a3370da2dc61ca2583ff90cb66ec17c6541735dd57R183)
* Updated StrongSORT to move the model and input tensors to the correct device (CPU/GPU) and use `torch.no_grad()` during inference for improved reliability and performance. [[1]](diffhunk://#diff-69f5810c3749db8e7792302c6d2aa3d257e53d38d61986c346828045c5ed2b55R29) [[2]](diffhunk://#diff-69f5810c3749db8e7792302c6d2aa3d257e53d38d61986c346828045c5ed2b55L54-R56)

**Minor citation formatting:**

* Fixed minor formatting in the BibTeX citations for both LITE and the evaluation framework papers in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L202-R291) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L213-L218)